### PR TITLE
Clear notifications older than 7 days

### DIFF
--- a/src/notifs-route.ts
+++ b/src/notifs-route.ts
@@ -6,7 +6,7 @@ type CreateNotifQuery = {
 	message?: string;
 };
 
-const ONE_DAY_MS = 24 * 60 * 60 * 1000;
+const SEVEN_DAYS_MS = 7 * 24 * 60 * 60 * 1000;
 
 export default function addNotifsRoute(fastify: FastifyInstance) {
 	fastify.post(
@@ -37,7 +37,7 @@ export default function addNotifsRoute(fastify: FastifyInstance) {
 			const notifications = await Notification.find({}).sort({ timestamp: -1 }).lean().exec();
 			reply.code(200).send(notifications);
 
-			const cutoff = Date.now() - ONE_DAY_MS;
+			const cutoff = Date.now() - SEVEN_DAYS_MS;
 			void Notification.deleteMany({ timestamp: { $lt: cutoff } }).catch((error) => {
 				console.error('Failed to cleanup old notifications', error);
 			});


### PR DESCRIPTION
### Motivation
- Increase the retention window used when cleaning up notifications so fetched notifications only remove items older than 7 days instead of 1 day.

### Description
- Replace the 1-day constant with `SEVEN_DAYS_MS = 7 * 24 * 60 * 60 * 1000` and update the cutoff computation in `src/notifs-route.ts` so `Notification.deleteMany` removes documents with `timestamp < Date.now() - SEVEN_DAYS_MS`.

### Testing
- Ran `npm test` (which runs `tsc --noEmit`) and the typecheck completed successfully.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69b199302e8c8331b9d12b3c765f82d0)